### PR TITLE
Implemented new tool to get IFC quantities

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Bonsai-mcp is a fork of [BlenderMCP](https://github.com/ahujasid/blender-mcp) th
 
 ## Features
 
--  **IFC-specific functionality**: Query IFC models, analyze spatial structures, and examine building elements
+-  **IFC-specific functionality**: Query IFC models, analyze spatial structures, examine building elements and extract quantities
 
 -  **Eleven IFC tools included**: Inspect project info, list entities, examine properties, explore spatial structure, analyze relationships and more
 
@@ -224,6 +224,8 @@ This repo includes nine IFC-specific tools that enable comprehensive querying an
 
 **place_ifc_object**: Creates and positions an IFC element in the model at specified coordinates with optional rotation. Example: "Place a door at coordinates X:10, Y:5, Z:0 with 90 degrees rotation"
 
+**get_ifc_quantities**: Calculate and get quantities (m2, m3, etc.) for IFC elements, with options to filter by entity type or selected ones. Example: "Give me the area of all the walls in the building using the tool get_ifc_quantities"
+
 ## Execute Blender Code
 
 Legacy feature from the original MCP implementation. Allows Claude to execute arbitrary Python code in Blender. Use with caution.
@@ -253,6 +255,8 @@ Here are some examples of what you can ask Claude to do with IFC models:
 - "Identify all structural elements in this building"
 
 - "What are the relationships between this wall and other elements?"
+
+- "Generate a report of the measurements from the IFC model opened in Blender"
 
 - "Use sequential thinking to create a maintenance plan for this building based on the IFC model"
 

--- a/tools.py
+++ b/tools.py
@@ -703,6 +703,24 @@ def get_user_view() -> Image:
         raise Exception(f"Error processing viewport image: {str(e)}")
 
 
+@mcp.tool()
+def get_ifc_quantities() -> str:
+    """
+    Extract and get basic qtos about the IFC project.
+    
+    Returns:
+        A JSON-formatted string with project quantities information
+    """
+    try:
+        blender = get_blender_connection()
+        result = blender.send_command("get_ifc_quantities")
+        
+        # Return the formatted JSON of the results
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error getting IFC project quantities: {str(e)}")
+        return f"Error getting IFC project quantities: {str(e)}"
+
 
 # WIP, not ready to be implemented:  
 # @mcp.tool()


### PR DESCRIPTION
## ✨ New Tool: `get_ifc_quantities`

This PR implements a new tool called **`get_ifc_quantities`** for extracting quantities from an IFC file.  
It leverages **Bonsai's native Qto extraction tool** to collect all the properties with quantities from the IFC entities contained in the IFC model opened in **Blender-Bonsai**.

### Motivation
Provides an easy way for AIs to programmatically access IFC quantities.

### Testing
- Opened an IFC model in Blender-Bonsai.
- Ran the tool to confirm quantities are correctly extracted.
- Verified output matches the properties defined in the IFC entities.

### Documentation
Usage instructions are available in the [`README.md`](./README.md).
