### PR TITLE
Fix Docker build for current mcp/mcpo releases

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -3,10 +3,11 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Copy your application files
-COPY tools.py /app/
+COPY tools.py bc3_writer.py /app/
 
 # Install dependencies
-RUN pip install mcpo uv
+# Pin mcp < 2.0.0: mcp 2.0.0 removed streamablehttp_client, which mcpo imports.
+RUN pip install "mcpo" "mcp[cli]<2.0.0"
 
 # Set environment variables with defaults
 ENV MCP_HOST="0.0.0.0"
@@ -24,8 +25,8 @@ sed -i "s/host=\"localhost\"/host=\"$BLENDER_HOST\"/g" tools.py\n\
 sed -i "s/host='\''localhost'\''/host='\''$BLENDER_HOST'\''/g" tools.py\n\
 # Print the modification for debugging\n\
 echo "Modified Blender host to: $BLENDER_HOST"\n\
-# Run the MCPO server\n\
-uvx mcpo --host $MCP_HOST --port $MCP_PORT -- python tools.py\n\
+# Run the MCPO server (use the pip-installed mcpo so the mcp<2.0.0 pin applies)\n\
+mcpo --host $MCP_HOST --port $MCP_PORT -- python tools.py\n\
 ' > /app/start.sh && chmod +x /app/start.sh
 
 # Run the startup script

--- a/tools.py
+++ b/tools.py
@@ -196,7 +196,6 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[Dict[str, Any]]:
 # Create the MCP server with lifespan support
 mcp = FastMCP(
     "Bonsai MCP",
-    description="IFC manipulation through Blender and MCP",
     lifespan=server_lifespan
 )
 


### PR DESCRIPTION
The container fails to start from a fresh clone because the unpinned install now resolves incompatible package versions.

- `mcp` 2.0.0 removed `streamablehttp_client`, which `mcpo` imports on startup, so `uvx mcpo` crashes with an ImportError. Pin `mcp[cli] < 2.0.0` and run the pip-installed `mcpo` directly instead of `uvx` (uvx re-resolved to 2.0.0 regardless of the base image).
- `tools.py` imports `bc3_writer` but the Dockerfile never copied it into the image, causing `ModuleNotFoundError`. Copy it alongside `tools.py`.
- `FastMCP` dropped the `description` kwarg in newer `mcp` releases; remove it from the server constructor.

With these three changes the OpenAPI proxy comes up cleanly on :8000.